### PR TITLE
No need for implicit core imports anymore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
-#![feature(core)]
 #![feature(no_std)]
 #![no_std]
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
-
-extern crate core;
 
 pub mod raw;
 

--- a/src/raw/console.rs
+++ b/src/raw/console.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use super::c_void;
 
 use super::gfx::*;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -16,9 +16,6 @@ pub mod services;
 
 pub use self::types::*;
 
-extern crate core;
-use core::option::Option;
-
 #[repr(u8)]
 pub enum c_void {
     __variant1,

--- a/src/raw/services/apt.rs
+++ b/src/raw/services/apt.rs
@@ -1,6 +1,3 @@
-extern crate core;
-use core::option::Option;
-
 use ::{Handle, Result};
 use ::raw::c_void;
 

--- a/src/raw/services/gsp.rs
+++ b/src/raw/services/gsp.rs
@@ -1,8 +1,5 @@
 use super::super::types::*;
 
-extern crate core;
-use core::clone::Clone;
-
 #[inline]
 pub fn GSP_REBASE_REG(r: u32) {
     ((r)-0x1EB00000);

--- a/src/raw/svc.rs
+++ b/src/raw/svc.rs
@@ -1,9 +1,6 @@
 use super::*;
 use super::super::{Handle, Result};
 
-extern crate core;
-use core::clone::Clone;
-
 #[repr(C)]
 pub enum MemOp {
     MEMOP_FREE = 1,

--- a/src/services/gsp.rs
+++ b/src/services/gsp.rs
@@ -1,5 +1,3 @@
-use ::Result;
-
 use ::raw::services::gsp;
 
 pub enum Event {


### PR DESCRIPTION
There is an implicit

``` rust
extern crate core;

use core::prelude::*;
```

by default now, so there is no need to do this, even with the core shim. Otherwise, you'll be greeted by a compiler error complaining about conflicting `core` crates.
