### PR TITLE
API overhaul and simplification, plus console support

### DIFF
--- a/3ds.json
+++ b/3ds.json
@@ -18,12 +18,13 @@
   "dynamic-linking": false,
   "no-compiler-rt": true,
   "exe-suffix": ".elf",
-  "pre-link-args": ["-specs",
+  "is-like-windows": true,
+  "function-sections": false,
+  "pre-link-args": [
+    "-specs",
     "3dsx.specs",
     "-march=armv6k",
     "-mtune=mpcore",
     "-mfloat-abi=hard"
-  ],
-  "is-like-windows": true,
-  "function-sections": false
+  ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
-name = "ctru-rs"
-version = "0.2.0"
-description = "A safe wrapper around smealum's ctrulib."
-authors = ["Ronald Kinard <furyhunter600@gmail.com>"] 
-links = "ctru"
+authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
 build = "build.rs"
+description = "A safe wrapper around smealum's ctrulib."
 license = "https://en.wikipedia.org/wiki/Zlib_License"
-
-[lib]
-name = "ctru"
-crate-type = ["rlib"]
+links = "ctru"
+name = "ctru-rs"
+version = "0.2.1"
 
 [dependencies]
-ctru-sys = { path = "ctru-sys" }
+rcstring = "0.2.1"
+
+[dependencies.ctru-sys]
+path = "ctru-sys"
+
+[lib]
+crate-type = ["rlib"]
+name = "ctru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A safe wrapper around smealum's ctrulib."
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 links = "ctru"
 name = "ctru-rs"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies.ctru-sys]
 path = "ctru-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ links = "ctru"
 name = "ctru-rs"
 version = "0.2.1"
 
-[dependencies]
-rcstring = "0.2.1"
-
 [dependencies.ctru-sys]
 path = "ctru-sys"
 

--- a/ctru-sys/src/console.rs
+++ b/ctru-sys/src/console.rs
@@ -1,4 +1,4 @@
-use c_void;
+use libc::c_void;
 
 use super::gfx::*;
 

--- a/ctru-sys/src/console.rs
+++ b/ctru-sys/src/console.rs
@@ -35,26 +35,31 @@ pub struct PrintConsole {
     pub consoleInitialised: u8,
 }
 
-pub const CONSOLE_COLOR_BOLD:    i32 = 1;
-pub const CONSOLE_COLOR_FAINT:   i32 = 2;
-pub const CONSOLE_ITALIC:        i32 = 4;
-pub const CONSOLE_UNDERLINE:     i32 = 8;
-pub const CONSOLE_BLINK_SLOW:    i32 = 16;
-pub const CONSOLE_BLINK_FAST:    i32 = 32;
+pub const CONSOLE_COLOR_BOLD: i32 = 1;
+pub const CONSOLE_COLOR_FAINT: i32 = 2;
+pub const CONSOLE_ITALIC: i32 = 4;
+pub const CONSOLE_UNDERLINE: i32 = 8;
+pub const CONSOLE_BLINK_SLOW: i32 = 16;
+pub const CONSOLE_BLINK_FAST: i32 = 32;
 pub const CONSOLE_COLOR_REVERSE: i32 = 64;
-pub const CONSOLE_CONCEAL:       i32 = 128;
+pub const CONSOLE_CONCEAL: i32 = 128;
 
 #[repr(C)]
 pub enum debugDevice {
-    NULL    = 0,
-    _3DMOO   = 1,
+    NULL = 0,
+    _3DMOO = 1,
     CONSOLE = 2,
 }
 
 
 extern "C" {
     pub fn consoleSetFont(console: *mut PrintConsole, font: *mut ConsoleFont) -> ();
-    pub fn consoleSetWindow(console: *mut PrintConsole, x: i32, y: i32, width: i32, height: i32) -> ();
+    pub fn consoleSetWindow(console: *mut PrintConsole,
+                            x: i32,
+                            y: i32,
+                            width: i32,
+                            height: i32)
+                            -> ();
     pub fn consoleGetDefault() -> *mut PrintConsole;
     pub fn consoleSelect(console: *mut PrintConsole) -> *mut PrintConsole;
     pub fn consoleInit(screen: gfxScreen_t, console: *mut PrintConsole) -> *mut PrintConsole;

--- a/ctru-sys/src/ipc.rs
+++ b/ctru-sys/src/ipc.rs
@@ -1,4 +1,4 @@
-//TODO: Implement static inline functions + solve the anonymous enum enigma
+//TODO: Implement static inline functions
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -7,4 +7,3 @@ pub enum IPC_BufferRights {
     IPC_BUFFER_W = 4,
     IPC_BUFFER_RW = 6,
 }
-

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gfx;
 pub mod gpu;
 pub mod ipc;
 pub mod lock;
+pub mod libc;
 pub mod os;
 pub mod sdmc;
 pub mod srv;
@@ -29,10 +30,4 @@ pub use self::types::*;
 pub type Result = i32;
 pub type Handle = u32;
 
-#[repr(u8)]
-pub enum c_void {
-    __variant1,
-    __variant2,
-}
-
-pub type ThreadFunc = Option<extern "C" fn(arg1: *mut c_void) -> ()>;
+pub type ThreadFunc = Option<extern "C" fn(arg1: *mut libc::c_void) -> ()>;

--- a/ctru-sys/src/libc.rs
+++ b/ctru-sys/src/libc.rs
@@ -1,0 +1,11 @@
+pub const STDOUT_FILENO: i32 = 1;
+
+#[repr(u8)]
+pub enum c_void {
+    __variant1,
+    __variant2,
+}
+
+extern "C" {
+    pub fn write(fd: i32, buf: *const c_void, count: usize) -> isize;
+}

--- a/ctru-sys/src/os.rs
+++ b/ctru-sys/src/os.rs
@@ -1,6 +1,7 @@
 //TODO: Fix Bindgen's issues again. 
 
 use ::Result;
+use libc::c_void;
 use types::*;
 
 #[inline]
@@ -35,9 +36,9 @@ impl ::core::default::Default for Struct_Unnamed2 {
 }
 pub type OS_VersionBin = Struct_Unnamed2;
 extern "C" {
-    pub fn osConvertVirtToPhys(vaddr: *const ::c_void) -> u32;
-    pub fn osConvertOldLINEARMemToNew(vaddr: *const ::c_void)
-     -> *mut ::c_void;
+    pub fn osConvertVirtToPhys(vaddr: *const c_void) -> u32;
+    pub fn osConvertOldLINEARMemToNew(vaddr: *const c_void)
+     -> *mut c_void;
     pub fn osStrError(error: u32) -> *const u8;
     pub fn osGetMemRegionUsed(region: MemRegion) -> s64;
     pub fn osGetTime() -> u64;

--- a/ctru-sys/src/result.rs
+++ b/ctru-sys/src/result.rs
@@ -1,0 +1,54 @@
+//TODO: Implement C macro functions? Maybe?
+
+//Result code level values
+pub const RL_SUCCESS :i32 = 0;
+pub const RL_INFO :i32 = 1;
+pub const RL_FATAL :i32 = 31;
+pub const RL_RESET :i32 = 30;
+pub const RL_REINITIALIZE :i32 = 29;
+pub const RL_USAGE :i32 = 28;
+pub const RL_PERMANENT :i32 = 27;
+pub const RL_TEMPORARY :i32 = 26;
+pub const RL_STATUS :i32 = 25;
+
+//Result code summary values
+pub const RS_SUCCESS :i32 = 0;
+pub const RS_NOP :i32 = 1;
+pub const RS_WOULDBLOCK :i32 = 2;
+pub const RS_OUTOFRESOURCE :i32 = 3;
+pub const RS_NOTFOUND :i32 = 4;
+pub const RS_INVALIDSTATE :i32 = 5;
+pub const RS_NOTSUPPORTED :i32 = 6;
+pub const RS_INVALIDARG :i32 = 7;
+pub const RS_WRONGARG :i32 = 8;
+pub const RS_CANCELED :i32 = 9;
+pub const RS_STATUSCHANGED :i32 = 10;
+pub const RS_INTERNAL :i32 = 11;
+pub const RS_INVALIDRESVAL :i32 = 63;
+
+//Result code generic description values
+pub const RD_SUCCESS :i32 = 0;
+pub const RD_INVALID_RESULT_VALUE :i32 = 1023;
+pub const RD_TIMEOUT :i32 = 1022;
+pub const RD_OUT_OF_RANGE :i32 = 1021;
+pub const RD_ALREADY_EXISTS :i32 = 1020;
+pub const RD_CANCEL_REQUESTED :i32 = 1019;
+pub const RD_NOT_FOUND :i32 = 1018;
+pub const RD_ALREADY_INITIALIZED :i32 = 1017;
+pub const RD_NOT_INITIALIZED :i32 = 1016;
+pub const RD_INVALID_HANDLE :i32 = 1015;
+pub const RD_INVALID_POINTER :i32 = 1014;
+pub const RD_INVALID_ADDRESS :i32 = 1013;
+pub const RD_NOT_IMPLEMENTED :i32 = 1012;
+pub const RD_OUT_OF_MEMORY :i32 = 1011;
+pub const RD_MISALIGNED_SIZE :i32 = 1010;
+pub const RD_MISALIGNED_ADDRESS :i32 = 1009;
+pub const RD_BUSY :i32 = 1008;
+pub const RD_NO_DATA :i32 = 1007;
+pub const RD_INVALID_COMBINATION :i32 = 1006;
+pub const RD_INVALID_ENUM_VALUE :i32 = 1005;
+pub const RD_INVALID_SIZE :i32 = 1004;
+pub const RD_ALREADY_DONE :i32 = 1003;
+pub const RD_NOT_AUTHORIZED :i32 = 1002;
+pub const RD_TOO_LARGE :i32 = 1001;
+pub const RD_INVALID_SELECTION :i32 = 1000;

--- a/ctru-sys/src/services/apt.rs
+++ b/ctru-sys/src/services/apt.rs
@@ -1,5 +1,5 @@
 use ::{Result, Handle};
-use ::c_void;
+use ::libc::c_void;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/ctru-sys/src/services/cam.rs
+++ b/ctru-sys/src/services/cam.rs
@@ -1,7 +1,7 @@
 // TODO: Determine if anonymous enums are properly represented (they probably aren't)
 
 use ::{Handle, Result};
-use ::c_void;
+use libc::c_void;
 use ::types::*;
 
 #[derive(Clone, Copy)]

--- a/ctru-sys/src/services/dsp.rs
+++ b/ctru-sys/src/services/dsp.rs
@@ -1,5 +1,5 @@
 use ::{Handle, Result};
-use ::c_void;
+use ::libc::c_void;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/ctru-sys/src/services/fs.rs
+++ b/ctru-sys/src/services/fs.rs
@@ -1,6 +1,7 @@
 // TODO: Determine if anonymous enums are properly represented (they probably aren't)
 
 use ::{Handle, Result};
+use ::libc::c_void;
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -276,7 +277,7 @@ pub type FS_DeviceMoveContext = Struct_Unnamed24;
 pub struct Struct_Unnamed25 {
     pub _type: FS_PathType,
     pub size: u32,
-    pub data: *const ::c_void,
+    pub data: *const c_void,
 }
 impl ::core::clone::Clone for Struct_Unnamed25 {
     fn clone(&self) -> Self { *self }
@@ -305,12 +306,12 @@ extern "C" {
     pub fn fsExit();
     pub fn fsUseSession(session: Handle, sdmc: u8);
     pub fn fsEndUseSession();
-    pub fn fsMakePath(_type: FS_PathType, path: *const ::c_void)
+    pub fn fsMakePath(_type: FS_PathType, path: *const c_void)
      -> FS_Path;
     pub fn fsGetSessionHandle() -> *mut Handle;
     pub fn FSUSER_Control(action: FS_Action,
-                          input: *mut ::c_void, inputSize: u32,
-                          output: *mut ::c_void,
+                          input: *mut c_void, inputSize: u32,
+                          output: *mut c_void,
                           outputSize: u32) -> Result;
     pub fn FSUSER_Initialize(session: Handle) -> Result;
     pub fn FSUSER_OpenFile(out: *mut Handle, archive: FS_Archive,
@@ -339,9 +340,9 @@ extern "C" {
     pub fn FSUSER_OpenArchive(archive: *mut FS_Archive) -> Result;
     pub fn FSUSER_ControlArchive(archive: FS_Archive,
                                  action: FS_ArchiveAction,
-                                 input: *mut ::c_void,
+                                 input: *mut c_void,
                                  inputSize: u32,
-                                 output: *mut ::c_void,
+                                 output: *mut c_void,
                                  outputSize: u32) -> Result;
     pub fn FSUSER_CloseArchive(archive: *mut FS_Archive) -> Result;
     pub fn FSUSER_GetFreeBytes(freeBytes: *mut u64, archive: FS_Archive)
@@ -495,22 +496,22 @@ extern "C" {
                                          titleUniqueId: u32,
                                          titleVariation: u8) -> Result;
     pub fn FSUSER_ControlSecureSave(action: FS_SecureSaveAction,
-                                    input: *mut ::c_void,
+                                    input: *mut c_void,
                                     inputSize: u32,
-                                    output: *mut ::c_void,
+                                    output: *mut c_void,
                                     outputSize: u32) -> Result;
     pub fn FSUSER_GetMediaType(mediaType: *mut FS_MediaType) -> Result;
     pub fn FSFILE_Control(handle: Handle, action: FS_FileAction,
-                          input: *mut ::c_void, inputSize: u32,
-                          output: *mut ::c_void,
+                          input: *mut c_void, inputSize: u32,
+                          output: *mut c_void,
                           outputSize: u32) -> Result;
     pub fn FSFILE_OpenSubFile(handle: Handle, subFile: *mut Handle,
                               offset: u64, size: u64) -> Result;
     pub fn FSFILE_Read(handle: Handle, bytesRead: *mut u32, offset: u64,
-                       buffer: *mut ::c_void, size: u32)
+                       buffer: *mut c_void, size: u32)
      -> Result;
     pub fn FSFILE_Write(handle: Handle, bytesWritten: *mut u32, offset: u64,
-                        buffer: *const ::c_void, size: u32,
+                        buffer: *const c_void, size: u32,
                         flags: u32) -> Result;
     pub fn FSFILE_GetSize(handle: Handle, size: *mut u64) -> Result;
     pub fn FSFILE_SetSize(handle: Handle, size: u64) -> Result;
@@ -524,8 +525,8 @@ extern "C" {
     pub fn FSFILE_OpenLinkFile(handle: Handle, linkFile: *mut Handle)
      -> Result;
     pub fn FSDIR_Control(handle: Handle, action: FS_DirectoryAction,
-                         input: *mut ::c_void, inputSize: u32,
-                         output: *mut ::c_void,
+                         input: *mut c_void, inputSize: u32,
+                         output: *mut c_void,
                          outputSize: u32) -> Result;
     pub fn FSDIR_Read(handle: Handle, entriesRead: *mut u32,
                       entryCount: u32, entries: *mut FS_DirectoryEntry)

--- a/ctru-sys/src/services/gspgpu.rs
+++ b/ctru-sys/src/services/gspgpu.rs
@@ -1,5 +1,5 @@
 use ::{Handle, Result};
-use ::c_void;
+use ::libc::c_void;
 use ::types::*;
 
 #[inline]

--- a/ctru-sys/src/services/hb.rs
+++ b/ctru-sys/src/services/hb.rs
@@ -1,5 +1,5 @@
 use ::Result;
-use ::c_void;
+use ::libc::c_void;
 
 
 extern "C" {

--- a/ctru-sys/src/services/news.rs
+++ b/ctru-sys/src/services/news.rs
@@ -1,5 +1,5 @@
 use ::Result;
-use ::c_void;
+use ::libc::c_void;
 
 extern "C" {
     pub fn newsInit() -> Result;

--- a/ctru-sys/src/services/pm.rs
+++ b/ctru-sys/src/services/pm.rs
@@ -1,5 +1,5 @@
 use ::{Handle, Result};
-use ::c_void;
+use ::libc::c_void;
 
 extern "C" {
     pub fn pmInit() -> Result;

--- a/ctru-sys/src/services/srvpm.rs
+++ b/ctru-sys/src/services/srvpm.rs
@@ -1,5 +1,5 @@
 use ::{Handle, Result};
-use ::c_void;
+use ::libc::c_void;
 
 extern "C" {
     pub fn srvPmInit() -> Result;

--- a/ctru-sys/src/services/y2r.rs
+++ b/ctru-sys/src/services/y2r.rs
@@ -1,5 +1,5 @@
 use ::{Handle, Result};
-use ::c_void;
+use ::libc::c_void;
 use ::types::*;
 
 #[derive(Clone, Copy)]

--- a/ctru-sys/src/srv.rs
+++ b/ctru-sys/src/srv.rs
@@ -1,5 +1,5 @@
 use {Result, Handle};
-use c_void;
+use libc::c_void;
 
 extern "C" {
     pub fn srvInit() -> Result;

--- a/ctru-sys/src/svc.rs
+++ b/ctru-sys/src/svc.rs
@@ -1,7 +1,7 @@
 //TODO: Implement static functions
 
 use {Handle, Result};
-use c_void;
+use libc::c_void;
 use ThreadFunc;
 use types::*;
 

--- a/ctru-sys/src/thread.rs
+++ b/ctru-sys/src/thread.rs
@@ -1,5 +1,5 @@
 use {Handle, Result};
-use c_void;
+use libc::c_void;
 use ThreadFunc;
 
 pub enum Struct_Thread_tag { }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,34 +1,17 @@
 use libctru::console::{consoleInit, consoleClear};
 use libctru::gfx;
+use libctru::libc;
 
+use core::fmt::{self, Write};
 use core::default::Default;
 use core::marker::PhantomData;
 use core::ptr;
-
-extern "C" {
-    fn putchar(ch: u8) -> i32;
-}
 
 pub struct Console {
     pd: PhantomData<()>,
 }
 
 impl Console {
-    pub fn print<'a>(&mut self, s: &'a str) {
-        unsafe {
-            for ch in s.as_bytes().iter() {
-                putchar(*ch);
-            }
-        }
-    }
-
-    pub fn println<'a>(&mut self, s: &'a str) {
-        unsafe {
-            self.print(s);
-            putchar('\n' as u8);
-        }
-    }
-
     pub fn clear(&mut self) {
         unsafe { consoleClear() }
     }
@@ -36,7 +19,20 @@ impl Console {
 
 impl Default for Console {
     fn default() -> Self {
-        unsafe { consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut()); }
+        unsafe {
+            consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut());
+        }
         Console { pd: PhantomData }
+    }
+}
+
+impl Write for Console {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let ret = unsafe { libc::write(libc::STDOUT_FILENO, s.as_ptr() as *const _, s.len()) };
+        if ret == s.len() as isize {
+            Ok(())
+        } else {
+            Err(fmt::Error)
+        }
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -10,11 +10,11 @@ extern "C" {
 }
 
 pub struct Console {
-    pd: PhantomData<i32>,
+    pd: PhantomData<()>,
 }
 
 impl Console {
-    pub fn write<'a>(&mut self, s: &'a str) {
+    pub fn print<'a>(&mut self, s: &'a str) {
         unsafe {
             for ch in s.as_bytes().iter() {
                 putchar(*ch);
@@ -22,9 +22,9 @@ impl Console {
         }
     }
 
-    pub fn writeln<'a>(&mut self, s: &'a str) {
+    pub fn println<'a>(&mut self, s: &'a str) {
         unsafe {
-            self.write(s);
+            self.print(s);
             putchar('\n' as u8);
         }
     }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,17 +1,31 @@
-use libctru::console::{PrintConsole, consoleInit};
+use libctru::console::{PrintConsole, consoleInit, consoleClear};
 use libctru::gfx;
-use rcstring::CString;
 
 use core::ptr;
 
 extern "C" {
-    fn puts(cstr: *const u8) -> u8;
+    fn putchar(ch: u8) -> i32;
 }
 
 pub fn console_default_init() -> *mut PrintConsole {
     unsafe { consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut()) }
 }
 
-pub fn console_write<'a>(s: &'a str) -> u8 {
-    unsafe { puts(CString::new(s).unwrap().into_raw()) }
+pub fn console_write<'a>(s: &'a str) {
+    unsafe {
+        for c in s.as_bytes().iter() {
+            putchar(*c);
+        }
+    }
+}
+
+pub fn console_writeln<'a>(s: &'a str) {
+    unsafe {
+        console_write(s);
+        putchar('\n' as u8);
+    }
+}
+
+pub fn console_clear() {
+    unsafe { consoleClear() }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,0 +1,17 @@
+use libctru::console::{PrintConsole, consoleInit};
+use libctru::gfx;
+use rcstring::CString;
+
+use core::ptr;
+
+extern "C" {
+    fn puts(cstr: *const u8) -> u8;
+}
+
+pub fn console_default_init() -> *mut PrintConsole {
+    unsafe { consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut()) }
+}
+
+pub fn console_write<'a>(s: &'a str) -> u8 {
+    unsafe { puts(CString::new(s).unwrap().into_raw()) }
+}

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,31 +1,42 @@
-use libctru::console::{PrintConsole, consoleInit, consoleClear};
+use libctru::console::{consoleInit, consoleClear};
 use libctru::gfx;
 
+use core::default::Default;
+use core::marker::PhantomData;
 use core::ptr;
 
 extern "C" {
     fn putchar(ch: u8) -> i32;
 }
 
-pub fn console_default_init() -> *mut PrintConsole {
-    unsafe { consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut()) }
+pub struct Console {
+    pd: PhantomData<i32>,
 }
 
-pub fn console_write<'a>(s: &'a str) {
-    unsafe {
-        for c in s.as_bytes().iter() {
-            putchar(*c);
+impl Console {
+    pub fn write<'a>(&mut self, s: &'a str) {
+        unsafe {
+            for ch in s.as_bytes().iter() {
+                putchar(*ch);
+            }
         }
     }
-}
 
-pub fn console_writeln<'a>(s: &'a str) {
-    unsafe {
-        console_write(s);
-        putchar('\n' as u8);
+    pub fn writeln<'a>(&mut self, s: &'a str) {
+        unsafe {
+            self.write(s);
+            putchar('\n' as u8);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        unsafe { consoleClear() }
     }
 }
 
-pub fn console_clear() {
-    unsafe { consoleClear() }
+impl Default for Console {
+    fn default() -> Self {
+        unsafe { consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut()); }
+        Console { pd: PhantomData }
+    }
 }

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -4,65 +4,69 @@ use core::default::Default;
 use core::marker::PhantomData;
 use core::ops::Drop;
 
-use ::services::gsp::FramebufferFormat;
+use services::gspgpu::FramebufferFormat;
 
 pub struct Gfx {
     // we do this to prevent people from making a Gfx struct manually
-    pd: PhantomData<i32>
+    pd: PhantomData<i32>,
 }
 
 #[derive(Copy, Clone)]
 pub enum Screen {
     Top,
-    Bottom
+    Bottom,
 }
 
 #[derive(Copy, Clone)]
 pub enum Side {
     Left,
-    Right
+    Right,
 }
 
 impl From<gfx::gfxScreen_t> for Screen {
-    #[inline] fn from(g: gfx::gfxScreen_t) -> Screen {
+    #[inline]
+    fn from(g: gfx::gfxScreen_t) -> Screen {
         use libctru::gfx::gfxScreen_t::*;
         use self::Screen::*;
         match g {
             GFX_TOP => Top,
-            GFX_BOTTOM => Bottom
+            GFX_BOTTOM => Bottom,
         }
     }
 }
 
 impl From<Screen> for gfx::gfxScreen_t {
-    #[inline] fn from(g: Screen) -> gfx::gfxScreen_t {
+    #[inline]
+    fn from(g: Screen) -> gfx::gfxScreen_t {
         use libctru::gfx::gfxScreen_t::*;
         use self::Screen::*;
         match g {
             Top => GFX_TOP,
-            Bottom => GFX_BOTTOM
+            Bottom => GFX_BOTTOM,
         }
     }
 }
 
 impl From<gfx::gfx3dSide_t> for Side {
-    #[inline] fn from(s: gfx::gfx3dSide_t) -> Side {
+    #[inline]
+    fn from(s: gfx::gfx3dSide_t) -> Side {
         use libctru::gfx::gfx3dSide_t::*;
         use self::Side::*;
         match s {
             GFX_LEFT => Left,
-            GFX_RIGHT => Right
+            GFX_RIGHT => Right,
         }
     }
 }
 
 impl From<Side> for gfx::gfx3dSide_t {
-    #[inline] fn from(s: Side) -> gfx::gfx3dSide_t {
+    #[inline]
+    fn from(s: Side) -> gfx::gfx3dSide_t {
         use libctru::gfx::gfx3dSide_t::*;
         use self::Side::*;
         match s {
             Left => GFX_LEFT,
-            Right => GFX_RIGHT
+            Right => GFX_RIGHT,
         }
     }
 }
@@ -70,18 +74,24 @@ impl From<Side> for gfx::gfx3dSide_t {
 impl Gfx {
     pub fn set_3d_enabled(&mut self, enabled: bool) {
         unsafe {
-            gfx::gfxSet3D(match enabled { true => 1u8, false => 0u8 });
+            gfx::gfxSet3D(match enabled {
+                true => 1u8,
+                false => 0u8,
+            });
         }
     }
 
-    pub fn get_framebuffer(& mut self, screen: Screen, side: Side) -> (&'static mut [u8], u16, u16) {
+    pub fn get_framebuffer(&mut self, screen: Screen, side: Side) -> (&'static mut [u8], u16, u16) {
         use core::convert::Into;
         unsafe {
             use core::slice::from_raw_parts_mut;
 
             let mut w: u16 = 0;
             let mut h: u16 = 0;
-            let buf: *mut u8 = gfx::gfxGetFramebuffer(screen.into(), side.into(), &mut w as *mut u16, &mut h as &mut u16);
+            let buf: *mut u8 = gfx::gfxGetFramebuffer(screen.into(),
+                                                      side.into(),
+                                                      &mut w as *mut u16,
+                                                      &mut h as &mut u16);
 
             let fbfmt = self.get_framebuffer_format(screen);
 
@@ -103,21 +113,21 @@ impl Gfx {
 
     pub fn get_framebuffer_format(&self, screen: Screen) -> FramebufferFormat {
         use core::convert::Into;
-        unsafe {
-            gfx::gfxGetScreenFormat(screen.into()).into()
-        }
+        unsafe { gfx::gfxGetScreenFormat(screen.into()).into() }
     }
 
     pub fn set_framebuffer_format(&mut self, screen: Screen, fmt: FramebufferFormat) {
         use core::convert::Into;
-        unsafe {
-            gfx::gfxSetScreenFormat(screen.into(), fmt.into())
-        }
+        unsafe { gfx::gfxSetScreenFormat(screen.into(), fmt.into()) }
     }
 
     pub fn set_double_buffering(&mut self, screen: Screen, enabled: bool) {
         unsafe {
-            gfx::gfxSetDoubleBuffering(screen.into(), match enabled { true => 1u8, false => 0u8 })
+            gfx::gfxSetDoubleBuffering(screen.into(),
+                                       match enabled {
+                                           true => 1u8,
+                                           false => 0u8,
+                                       })
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,17 @@
 #![no_std]
-#![feature(lang_items)]
+#![feature(lang_items, alloc, collections, slice_concat_ext, macro_reexport, allow_internal_unstable)]
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
 
-extern crate ctru_sys as libctru;
+extern crate alloc;
+#[macro_reexport(format, vec)]
+extern crate collections;
 
+extern crate ctru_sys as libctru;
+#[macro_use]
+extern crate rcstring;
+
+pub mod console;
 pub mod srv;
 pub mod gfx;
 pub mod sdmc;
@@ -15,5 +22,43 @@ pub use srv::Srv;
 pub use gfx::Gfx;
 pub use sdmc::Sdmc;
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+pub mod std {
+    pub use core::{any, cell, char, clone, cmp, convert, default, f32, f64, hash, i16, i32, i64,
+                   i8, isize, iter, marker, mem, num, ops, option, ptr, result, sync, u16, u32,
+                   u64, u8, usize};
+    pub use alloc::{arc, rc};
+    pub use collections::{borrow, boxed, fmt, slice, str, string, vec};
+
+    pub mod collections {
+        pub use collections::{binary_heap, btree_map, btree_set, linked_list, vec_deque,
+                              BinaryHeap, LinkedList, VecDeque, String, Vec, BTreeMap, BTreeSet};
+    }
+}
+
+pub mod prelude {
+    pub use std;
+    pub use std::marker::{Copy, Send, Sized, Sync};
+    pub use std::ops::{Drop, Fn, FnMut, FnOnce};
+    pub use std::mem::drop;
+    pub use std::boxed::Box;
+    pub use std::borrow::ToOwned;
+    pub use std::clone::Clone;
+    pub use std::cmp::{PartialEq, PartialOrd, Eq, Ord};
+    pub use std::convert::{AsRef, AsMut, Into, From};
+    pub use std::default::Default;
+    pub use std::iter::{Iterator, Extend, IntoIterator};
+    pub use std::iter::{DoubleEndedIterator, ExactSizeIterator};
+    pub use std::option::Option::{self, Some, None};
+    pub use std::result::Result::{self, Ok, Err};
+    pub use std::slice::SliceConcatExt;
+    pub use std::string::{String, ToString};
+    pub use std::vec::Vec;
+    pub use std::fmt::Write;
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+#[lang = "panic_fmt"]
+fn panic_fmt() -> ! {
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(lang_items, alloc, collections, slice_concat_ext, macro_reexport, allow_internal_unstable)]
+#![feature(lang_items, alloc, collections, macro_reexport, allow_internal_unstable)]
 #![no_std]
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
@@ -19,40 +19,6 @@ pub mod services;
 pub use srv::Srv;
 pub use gfx::Gfx;
 pub use sdmc::Sdmc;
-
-pub mod std {
-    pub use core::{any, cell, char, clone, cmp, convert, default, f32, f64, hash, i16, i32, i64,
-                   i8, isize, iter, marker, mem, num, ops, option, ptr, result, sync, u16, u32,
-                   u64, u8, usize};
-    pub use alloc::{arc, rc};
-    pub use collections::{borrow, boxed, fmt, slice, str, string, vec};
-
-    pub mod collections {
-        pub use collections::{binary_heap, btree_map, btree_set, linked_list, vec_deque,
-                              BinaryHeap, LinkedList, VecDeque, String, Vec, BTreeMap, BTreeSet};
-    }
-}
-
-pub mod prelude {
-    pub use std;
-    pub use std::marker::{Copy, Send, Sized, Sync};
-    pub use std::ops::{Drop, Fn, FnMut, FnOnce};
-    pub use std::mem::drop;
-    pub use std::boxed::Box;
-    pub use std::borrow::ToOwned;
-    pub use std::clone::Clone;
-    pub use std::cmp::{PartialEq, PartialOrd, Eq, Ord};
-    pub use std::convert::{AsRef, AsMut, Into, From};
-    pub use std::default::Default;
-    pub use std::iter::{Iterator, Extend, IntoIterator};
-    pub use std::iter::{DoubleEndedIterator, ExactSizeIterator};
-    pub use std::option::Option::{self, Some, None};
-    pub use std::result::Result::{self, Ok, Err};
-    pub use std::slice::SliceConcatExt;
-    pub use std::string::{String, ToString};
-    pub use std::vec::Vec;
-    pub use std::fmt::Write;
-}
 
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![no_std]
 #![feature(lang_items, alloc, collections, slice_concat_ext, macro_reexport, allow_internal_unstable)]
+#![no_std]
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
 
@@ -8,8 +8,6 @@ extern crate alloc;
 extern crate collections;
 
 extern crate ctru_sys as libctru;
-#[macro_use]
-extern crate rcstring;
 
 pub mod console;
 pub mod srv;

--- a/src/sdmc.rs
+++ b/src/sdmc.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use libctru::sdmc::*;
 
 pub struct Sdmc {
-    pd: PhantomData<i32>
+    pd: PhantomData<i32>,
 }
 
 impl Sdmc {
@@ -21,8 +21,6 @@ impl Sdmc {
 
 impl Drop for Sdmc {
     fn drop(&mut self) {
-        unsafe {
-            sdmcExit()
-        };
+        unsafe { sdmcExit() };
     }
 }

--- a/src/services/apt.rs
+++ b/src/services/apt.rs
@@ -79,7 +79,7 @@ impl Apt {
     }
 
     pub fn main_loop(&mut self) -> bool {
-        unsafe { 
+        unsafe {
             match apt::aptMainLoop() {
                 1 => true,
                 0 => false,

--- a/src/services/apt.rs
+++ b/src/services/apt.rs
@@ -17,16 +17,17 @@ pub enum AppStatus {
 impl From<AppStatus> for apt::APT_AppStatus {
     fn from(a: AppStatus) -> apt::APT_AppStatus {
         use self::AppStatus::*;
+        use libctru::services::apt::APT_AppStatus::*;
         match a {
-            NotInitialized => apt::APT_AppStatus::APP_NOTINITIALIZED,
-            Running => apt::APT_AppStatus::APP_RUNNING,
-            Suspended => apt::APT_AppStatus::APP_SUSPENDED,
-            Exiting => apt::APT_AppStatus::APP_EXITING,
-            Suspending => apt::APT_AppStatus::APP_SUSPENDING,
-            SleepMode => apt::APT_AppStatus::APP_SLEEPMODE,
-            PrepareSleepMode => apt::APT_AppStatus::APP_PREPARE_SLEEPMODE,
-            AppletStarted => apt::APT_AppStatus::APP_APPLETSTARTED,
-            AppletClosed => apt::APT_AppStatus::APP_APPLETCLOSED,
+            NotInitialized => APP_NOTINITIALIZED,
+            Running => APP_RUNNING,
+            Suspended => APP_SUSPENDED,
+            Exiting => APP_EXITING,
+            Suspending => APP_SUSPENDING,
+            SleepMode => APP_SLEEPMODE,
+            PrepareSleepMode => APP_PREPARE_SLEEPMODE,
+            AppletStarted => APP_APPLETSTARTED,
+            AppletClosed => APP_APPLETCLOSED,
         }
     }
 }
@@ -34,16 +35,17 @@ impl From<AppStatus> for apt::APT_AppStatus {
 impl From<apt::APT_AppStatus> for AppStatus {
     fn from(a: apt::APT_AppStatus) -> AppStatus {
         use self::AppStatus::*;
+        use libctru::services::apt::APT_AppStatus::*;
         match a {
-            apt::APT_AppStatus::APP_NOTINITIALIZED => NotInitialized,
-            apt::APT_AppStatus::APP_RUNNING => Running,
-            apt::APT_AppStatus::APP_SUSPENDED => Suspended,
-            apt::APT_AppStatus::APP_EXITING => Exiting,
-            apt::APT_AppStatus::APP_SUSPENDING => Suspending,
-            apt::APT_AppStatus::APP_SLEEPMODE => SleepMode,
-            apt::APT_AppStatus::APP_PREPARE_SLEEPMODE => PrepareSleepMode,
-            apt::APT_AppStatus::APP_APPLETSTARTED => AppletStarted,
-            apt::APT_AppStatus::APP_APPLETCLOSED => AppletClosed,
+            APP_NOTINITIALIZED => NotInitialized,
+            APP_RUNNING => Running,
+            APP_SUSPENDED => Suspended,
+            APP_EXITING => Exiting,
+            APP_SUSPENDING => Suspending,
+            APP_SLEEPMODE => SleepMode,
+            APP_PREPARE_SLEEPMODE => PrepareSleepMode,
+            APP_APPLETSTARTED => AppletStarted,
+            APP_APPLETCLOSED => AppletClosed,
         }
     }
 }
@@ -53,15 +55,8 @@ pub struct Apt {
 }
 
 impl Apt {
-    pub fn new() -> Result<Apt, i32> {
-        unsafe {
-            let r = apt::aptInit();
-            if r < 0 {
-                Err(r)
-            } else {
-                Ok(Apt { pd: PhantomData })
-            }
-        }
+    pub fn new() -> Apt {
+        Apt { pd: PhantomData }
     }
 
     pub fn get_status(&self) -> AppStatus {
@@ -80,31 +75,16 @@ impl Apt {
     /// The program will not return from this function until the system returns
     /// to the application, or when the status changes to `AppStatus::Exiting`.
     pub fn return_to_menu(&mut self) {
-        unsafe { apt::aptReturnToMenu() };
+        unsafe { apt::aptReturnToMenu() }
     }
 
-    pub fn main_loop(&mut self, app: &mut Application) {
-        unsafe {
-            while apt::aptMainLoop() != 0 {
-                app.main_loop(self);
-                if app.ready_to_quit() {
-                    self.set_status(AppStatus::Exiting)
-                }
+    pub fn main_loop(&mut self) -> bool {
+        unsafe { 
+            match apt::aptMainLoop() {
+                1 => true,
+                0 => false,
+                _ => unreachable!(),
             }
-        };
+        }
     }
-}
-
-impl Drop for Apt {
-    fn drop(&mut self) {
-        unsafe { apt::aptExit() };
-    }
-}
-
-pub trait Application {
-    /// Program app loop body.
-    fn main_loop(&mut self, apt: &mut Apt);
-
-    /// True if the application is ready to quit.
-    fn ready_to_quit(&self) -> bool;
 }

--- a/src/services/apt.rs
+++ b/src/services/apt.rs
@@ -11,7 +11,7 @@ pub enum AppStatus {
     SleepMode,
     PrepareSleepMode,
     AppletStarted,
-    AppletClosed
+    AppletClosed,
 }
 
 impl From<AppStatus> for apt::APT_AppStatus {
@@ -35,21 +35,21 @@ impl From<apt::APT_AppStatus> for AppStatus {
     fn from(a: apt::APT_AppStatus) -> AppStatus {
         use self::AppStatus::*;
         match a {
-             apt::APT_AppStatus::APP_NOTINITIALIZED => NotInitialized,
-             apt::APT_AppStatus::APP_RUNNING => Running,
-             apt::APT_AppStatus::APP_SUSPENDED => Suspended,
-             apt::APT_AppStatus::APP_EXITING => Exiting,
-             apt::APT_AppStatus::APP_SUSPENDING => Suspending,
-             apt::APT_AppStatus::APP_SLEEPMODE => SleepMode,
-             apt::APT_AppStatus::APP_PREPARE_SLEEPMODE => PrepareSleepMode,
-             apt::APT_AppStatus::APP_APPLETSTARTED => AppletStarted,
-             apt::APT_AppStatus::APP_APPLETCLOSED => AppletClosed
+            apt::APT_AppStatus::APP_NOTINITIALIZED => NotInitialized,
+            apt::APT_AppStatus::APP_RUNNING => Running,
+            apt::APT_AppStatus::APP_SUSPENDED => Suspended,
+            apt::APT_AppStatus::APP_EXITING => Exiting,
+            apt::APT_AppStatus::APP_SUSPENDING => Suspending,
+            apt::APT_AppStatus::APP_SLEEPMODE => SleepMode,
+            apt::APT_AppStatus::APP_PREPARE_SLEEPMODE => PrepareSleepMode,
+            apt::APT_AppStatus::APP_APPLETSTARTED => AppletStarted,
+            apt::APT_AppStatus::APP_APPLETCLOSED => AppletClosed,
         }
     }
 }
 
 pub struct Apt {
-    pd: PhantomData<()>
+    pd: PhantomData<()>,
 }
 
 impl Apt {

--- a/src/services/gspgpu.rs
+++ b/src/services/gspgpu.rs
@@ -9,7 +9,7 @@ pub enum Event {
     VBlank1,
     PPF,
     P3D,
-    DMA
+    DMA,
 }
 
 #[derive(Copy, Clone)]
@@ -18,7 +18,7 @@ pub enum FramebufferFormat {
     Bgr8,
     Rgb565,
     Rgb5A1,
-    Rgba4
+    Rgba4,
 }
 
 impl FramebufferFormat {
@@ -29,13 +29,14 @@ impl FramebufferFormat {
             Bgr8 => 3usize,
             Rgb565 => 2usize,
             Rgb5A1 => 2usize,
-            Rgba4 => 2usize
+            Rgba4 => 2usize,
         }
     }
 }
 
 impl From<gspgpu::GSPGPU_FramebufferFormats> for FramebufferFormat {
-    #[inline] fn from(g: gspgpu::GSPGPU_FramebufferFormats) -> FramebufferFormat {
+    #[inline]
+    fn from(g: gspgpu::GSPGPU_FramebufferFormats) -> FramebufferFormat {
         use libctru::services::gspgpu::GSPGPU_FramebufferFormats::*;
         use self::FramebufferFormat::*;
         match g {
@@ -43,13 +44,14 @@ impl From<gspgpu::GSPGPU_FramebufferFormats> for FramebufferFormat {
             GSP_BGR8_OES => Bgr8,
             GSP_RGB565_OES => Rgb565,
             GSP_RGB5_A1_OES => Rgb5A1,
-            GSP_RGBA4_OES => Rgba4
+            GSP_RGBA4_OES => Rgba4,
         }
     }
 }
 
 impl From<FramebufferFormat> for gspgpu::GSPGPU_FramebufferFormats {
-    #[inline] fn from(g: FramebufferFormat) -> gspgpu::GSPGPU_FramebufferFormats {
+    #[inline]
+    fn from(g: FramebufferFormat) -> gspgpu::GSPGPU_FramebufferFormats {
         use libctru::services::gspgpu::GSPGPU_FramebufferFormats::*;
         use self::FramebufferFormat::*;
         match g {
@@ -57,7 +59,7 @@ impl From<FramebufferFormat> for gspgpu::GSPGPU_FramebufferFormats {
             Bgr8 => GSP_BGR8_OES,
             Rgb565 => GSP_RGB565_OES,
             Rgb5A1 => GSP_RGB5_A1_OES,
-            Rgba4 => GSP_RGBA4_OES
+            Rgba4 => GSP_RGBA4_OES,
         }
     }
 }
@@ -73,7 +75,7 @@ fn to_raw_event(ev: Event) -> gspgpu::GSPGPU_Event {
         VBlank1 => GSPGPU_EVENT_VBlank1,
         PPF => GSPGPU_EVENT_PPF,
         P3D => GSPGPU_EVENT_P3D,
-        DMA => GSPGPU_EVENT_DMA
+        DMA => GSPGPU_EVENT_DMA,
     }
 }
 

--- a/src/services/hid.rs
+++ b/src/services/hid.rs
@@ -74,19 +74,12 @@ impl From<PadKey> for u32 {
 }
 
 pub struct Hid {
-    pd: PhantomData<i32>,
+    pd: PhantomData<()>,
 }
 
 impl Hid {
-    pub fn new() -> Result<Hid, i32> {
-        unsafe {
-            let r = hid::hidInit();
-            if r < 0 {
-                Err(r)
-            } else {
-                Ok(Hid { pd: PhantomData })
-            }
-        }
+    pub fn new() -> Hid {
+        Hid { pd: PhantomData }
     }
 
     pub fn scan_input(&mut self) {
@@ -124,11 +117,5 @@ impl Hid {
                 return false;
             }
         }
-    }
-}
-
-impl Drop for Hid {
-    fn drop(&mut self) {
-        unsafe { hid::hidExit() };
     }
 }

--- a/src/services/hid.rs
+++ b/src/services/hid.rs
@@ -32,7 +32,7 @@ pub enum PadKey {
     Up,
     Down,
     Left,
-    Right
+    Right,
 }
 
 impl From<PadKey> for u32 {
@@ -68,13 +68,13 @@ impl From<PadKey> for u32 {
             DPadLeft => KEY_DLEFT as u32,
             DPadRight => KEY_DRIGHT as u32,
             DPadUp => KEY_DUP as u32,
-            DPadDown => KEY_DDOWN as u32
+            DPadDown => KEY_DDOWN as u32,
         }
     }
 }
 
 pub struct Hid {
-    pd: PhantomData<i32>
+    pd: PhantomData<i32>,
 }
 
 impl Hid {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,4 +3,4 @@ pub mod hid;
 pub mod gspgpu;
 
 pub use self::hid::Hid;
-pub use self::apt::{Apt, Application};
+pub use self::apt::Apt;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,6 @@
 pub mod apt;
 pub mod hid;
-pub mod gsp;
+pub mod gspgpu;
 
 pub use self::hid::Hid;
 pub use self::apt::{Apt, Application};

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -3,7 +3,7 @@ use libctru::srv::*;
 use core::marker::PhantomData;
 
 pub struct Srv {
-    pd: PhantomData<i32>
+    pd: PhantomData<i32>,
 }
 
 impl Srv {


### PR DESCRIPTION
While examining standard C homebrew examples such as the good old [hello world](http://smealum.github.io/ctrulib/graphics_2printing_2hello-world_2source_2main_8c-example.html#a8) sample, I realized that the ctru-rs API has been somewhat overzealous with its RAII semantics. For example, you might notice that while the Gfx module requires explicit init and exit calls, the Apt and Hid modules require no manual initiation or dropping. The aptMainLoop() function and hidKeysDown() functions ...just kinda work somehow. The [documentation for ctrulib](http://smealum.github.io/ctrulib/md__home_travis_build_smealum_ctrulib_Changelog.html) suggests that many services are refcounted on the C side, so maybe that explains it. I also suspect that some services are automatically initialized by the homebrew launcher or the 3DS's OS in general and therefore don't require manual initialization.

So while I kept the RAII semantics intact for the Gfx module, I removed them from Apt, Srv, and Hid. The modules are still in the form of a struct+methods, but they no longer call their respective init and exit functions on instantiation and destruction. In addition to making an example [rust hello world](https://github.com/FenrirWolf/rust3ds-template/blob/master/src/main.rs) app much simpler in terms of both readability and control flow, another benefit of this change is that apps now properly return to the homebrew launcher instead of hanging indefinitely like they did before. This leads me to believe I'm on the right track with these changes.

I also implemented simple console support. It seems to work well enough, though at present it doesn't guard against non-ascii input and would likely choke horribly should it encounter any. I'm thinking that the next step would be to get the format! macro working so that a proper println! implementation could be added.
