### PR TITLE
Multiple console support + Bringing RAII back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A safe wrapper around smealum's ctrulib."
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 links = "ctru"
 name = "ctru-rs"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies.ctru-sys]
 path = "ctru-sys"

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,17 +1,26 @@
-use libctru::console::{consoleInit, consoleClear};
-use libctru::gfx;
+use libctru::console::*;
 use libctru::libc;
+
+use gfx::Screen;
 
 use core::fmt::{self, Write};
 use core::default::Default;
-use core::marker::PhantomData;
 use core::ptr;
 
 pub struct Console {
-    pd: PhantomData<()>,
+    context: PrintConsole,
 }
 
 impl Console {
+    pub fn init(screen: Screen) -> Self {
+        let ret = unsafe { *(consoleInit(screen.into(), ptr::null_mut())) };
+        Console { context: ret }
+    }
+
+    pub fn set_window(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        unsafe { consoleSetWindow(&mut self.context, x, y, width, height) }
+    } 
+
     pub fn clear(&mut self) {
         unsafe { consoleClear() }
     }
@@ -19,15 +28,14 @@ impl Console {
 
 impl Default for Console {
     fn default() -> Self {
-        unsafe {
-            consoleInit(gfx::gfxScreen_t::GFX_TOP, ptr::null_mut());
-        }
-        Console { pd: PhantomData }
+        let ret = unsafe { *(consoleInit(Screen::Top.into(), ptr::null_mut())) };
+        Console { context: ret }
     }
 }
 
 impl Write for Console {
     fn write_str(&mut self, s: &str) -> fmt::Result {
+        unsafe { consoleSelect(&mut self.context); }
         let ret = unsafe { libc::write(libc::STDOUT_FILENO, s.as_ptr() as *const _, s.len()) };
         if ret == s.len() as isize {
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
-#![feature(lang_items, alloc, collections, macro_reexport, allow_internal_unstable)]
+#![feature(lang_items)]
 #![no_std]
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
-
-extern crate alloc;
-#[macro_reexport(format, vec)]
-extern crate collections;
 
 extern crate ctru_sys as libctru;
 

--- a/src/sdmc.rs
+++ b/src/sdmc.rs
@@ -7,7 +7,7 @@ pub struct Sdmc {
 }
 
 impl Sdmc {
-    pub fn new() -> Result<Self, i32> {
+    pub fn new() -> Result<Sdmc, i32> {
         unsafe {
             let r = sdmcInit();
             if r < 0 {

--- a/src/services/apt.rs
+++ b/src/services/apt.rs
@@ -51,13 +51,21 @@ impl From<apt::APT_AppStatus> for AppStatus {
 }
 
 pub struct Apt {
-    pd: PhantomData<()>,
+    pd: PhantomData<i32>
 }
 
 impl Apt {
-    pub fn new() -> Apt {
-        Apt { pd: PhantomData }
+    pub fn new() -> Result<Apt, i32> {
+        unsafe {
+            let r = apt::aptInit();
+            if r < 0 {
+                Err(r)
+            } else {
+                Ok(Apt { pd: PhantomData })
+            }
+        }
     }
+
 
     pub fn get_status(&self) -> AppStatus {
         unsafe { apt::aptGetStatus().into() }
@@ -86,5 +94,11 @@ impl Apt {
                 _ => unreachable!(),
             }
         }
+    }
+}
+
+impl Drop for Apt {
+    fn drop(&mut self) {
+        unsafe { apt::aptExit() };
     }
 }

--- a/src/services/hid.rs
+++ b/src/services/hid.rs
@@ -74,12 +74,19 @@ impl From<PadKey> for u32 {
 }
 
 pub struct Hid {
-    pd: PhantomData<()>,
+    pd: PhantomData<i32>
 }
 
 impl Hid {
-    pub fn new() -> Hid {
-        Hid { pd: PhantomData }
+    pub fn new() -> Result<Hid, i32> {
+        unsafe {
+            let r = hid::hidInit();
+            if r < 0 {
+                Err(r)
+            } else {
+                Ok(Hid { pd: PhantomData })
+            }
+        }
     }
 
     pub fn scan_input(&mut self) {
@@ -117,5 +124,11 @@ impl Hid {
                 return false;
             }
         }
+    }
+}
+
+impl Drop for Hid {
+    fn drop(&mut self) {
+        unsafe { hid::hidExit() };
     }
 }


### PR DESCRIPTION
RAII is back for the modules that I removed it from earlier. Turns out that was not the cause of the crashes I experienced in the past, plus after looking at ctrulib's source some more I can see that incrementing the refcount for services isn't expensive at all. So yeah, no reason not to have it. I bumped the library version to 0.4 since this is technically a breaking change (again), and I'll push a fix to the template project once merged.

I also expanded the console API a bit. You can now have a console on each screen, or even multiple consoles on the same screen if you really want. From what I can tell, the only things left to implement from ctrulib's API are custom font support and debug printing.

I wonder, though, if it would be possible to implement a custom println! that just calls writeln!().unwrap(). It seems a bit silly having to unwrap() when writing to the console since, as far as I'm aware, it's an operation that can rarely or never fail. I'm pretty illiterate when it comes to Rust macros though so I'm not sure how to approach that problem.
