### PR TITLE
compiler-rt is no more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ path = "ctru-sys"
 [dependencies.alloc_system3ds]
 git = "https://github.com/rust3ds/alloc_system3ds"
 
+[dependencies.rustc_builtins]
+git = "https://github.com/japaric/rustc-builtins.git"
+
 [lib]
 crate-type = ["rlib"]
 name = "ctru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "ctru-sys"
 [dependencies.alloc_system3ds]
 git = "https://github.com/rust3ds/alloc_system3ds"
 
-[dependencies.rustc_builtins]
-git = "https://github.com/japaric/rustc-builtins.git"
+[dependencies.compiler_builtins]
+git = "https://github.com/rust-lang-nursery/compiler-builtins"
 
 [lib]
 crate-type = ["rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(alloc)]
 #![feature(collections)]
 #![feature(char_escape_debug)]
+#![feature(compiler_builtins_lib)]
 #![feature(lang_items)]
 #![feature(question_mark)]
 #![feature(slice_patterns)]
@@ -16,7 +17,7 @@ extern crate alloc;
 extern crate alloc_system;
 extern crate collections;
 extern crate rustc_unicode;
-extern crate rustc_builtins;
+extern crate compiler_builtins;
 
 extern crate ctru_sys as libctru;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 extern crate alloc_system;
 extern crate collections;
 extern crate rustc_unicode;
+extern crate rustc_builtins;
 
 extern crate ctru_sys as libctru;
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -17,9 +17,15 @@ use core::any::Any;
 use collections::String;
 use collections::boxed::Box;
 
-///The compiler wants this to be here. Otherwise it won't be happy. And we like happy compilers.
+// The compiler wants this to be here. Otherwise it won't be happy. And we like happy compilers.
 #[lang = "eh_personality"]
 extern fn eh_personality() {}
+
+// It also wants these functions because we're not linking libgcc anymore
+#[no_mangle]
+pub extern "C" fn __aeabi_unwind_cpp_pr0() {}
+#[no_mangle]
+pub extern "C" fn __aeabi_unwind_cpp_pr1() {}
 
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]


### PR DESCRIPTION
The creation of [rustc-builtins](https://github.com/japaric/rustc-builtins) means that we can finally drop our dependency on `compiler-rt`. The only catch is that enabling LTO seems to cause linker issues in `rustc-builtins`. I'm going to file an issue reporting the problem, but for now disabling LTO results in a successful build.

Fixes #2
