### PR TITLE
ctr-std: Mark thread::panicking

### DIFF
--- a/ctr-std/src/thread/mod.rs
+++ b/ctr-std/src/thread/mod.rs
@@ -195,6 +195,8 @@ pub use self::local::{LocalKey, LocalKeyState};
 #[doc(hidden)] pub use self::local::os::Key as __OsLocalKeyInner;
 
 // We don't have stack unwinding, so this should always be false
+#[inline]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn panicking() -> bool {
     false
 }


### PR DESCRIPTION
The compiler seems to panic when unmarked items from libstd are being used.