### PR TITLE
Make ctru-rs less spooky

### DIFF
--- a/ctru-rs/src/gfx.rs
+++ b/ctru-rs/src/gfx.rs
@@ -1,15 +1,11 @@
 use libctru::gfx;
 
 use std::default::Default;
-use std::marker::PhantomData;
 use std::ops::Drop;
 
 use services::gspgpu::FramebufferFormat;
 
-pub struct Gfx {
-    // we do this to prevent people from making a Gfx struct manually
-    pd: PhantomData<i32>,
-}
+pub struct Gfx(());
 
 #[derive(Copy, Clone)]
 pub enum Screen {
@@ -135,7 +131,7 @@ impl Gfx {
 impl Default for Gfx {
     fn default() -> Self {
         unsafe { gfx::gfxInitDefault() };
-        Gfx { pd: PhantomData }
+        Gfx(())
     }
 }
 

--- a/ctru-rs/src/sdmc.rs
+++ b/ctru-rs/src/sdmc.rs
@@ -1,19 +1,15 @@
-use std::marker::PhantomData;
-
 use libctru::sdmc::*;
 
-pub struct Sdmc {
-    pd: PhantomData<i32>,
-}
+pub struct Sdmc(());
 
 impl Sdmc {
     pub fn init() -> ::Result<Sdmc> {
         unsafe {
             let r = sdmcInit();
             if r < 0 {
-                Err(::Error::from(r))
+                Err(r.into())
             } else {
-                Ok(Sdmc { pd: PhantomData })
+                Ok(Sdmc(()))
             }
         }
     }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -1,19 +1,15 @@
-use std::marker::PhantomData;
-
 use libctru::services::apt;
 
-pub struct Apt {
-    pd: PhantomData<i32>
-}
+pub struct Apt(());
 
 impl Apt {
     pub fn init() -> ::Result<Apt> {
         unsafe {
             let r = apt::aptInit();
             if r < 0 {
-                Err(::Error::from(r))
+                Err(r.into())
             } else {
-                Ok(Apt { pd: PhantomData })
+                Ok(Apt(()))
             }
         }
     }

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -9,7 +9,6 @@ use std::io::Result as IoResult;
 use std::io::ErrorKind as IoErrorKind;
 
 use std::ffi::OsString;
-use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
 use std::mem;
@@ -83,9 +82,7 @@ pub enum ArchiveID {
 /// until an instance of this struct is created.
 ///
 /// The service exits when all instances of this struct go out of scope. 
-pub struct Fs {
-    pd: PhantomData<i32>,
-}
+pub struct Fs(());
 
 /// Handle to an open filesystem archive.
 ///
@@ -304,9 +301,9 @@ impl Fs {
         unsafe {
             let r = fsInit();
             if r < 0 {
-                Err(::Error::from(r))
+                Err(r.into())
             } else {
-                Ok(Fs { pd: PhantomData })
+                Ok(Fs(()))
             }
         }
     }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -1,5 +1,4 @@
 use std::convert::Into;
-use std::marker::PhantomData;
 
 use libctru::services::hid;
 
@@ -73,18 +72,16 @@ impl From<PadKey> for u32 {
     }
 }
 
-pub struct Hid {
-    pd: PhantomData<i32>
-}
+pub struct Hid(());
 
 impl Hid {
     pub fn init() -> ::Result<Hid> {
         unsafe {
             let r = hid::hidInit();
             if r < 0 {
-                Err(::Error::from(r))
+                Err(r.into())
             } else {
-                Ok(Hid { pd: PhantomData })
+                Ok(Hid(()))
             }
         }
     }

--- a/ctru-rs/src/srv.rs
+++ b/ctru-rs/src/srv.rs
@@ -1,19 +1,15 @@
 use libctru::srv::*;
 
-use std::marker::PhantomData;
-
-pub struct Srv {
-    pd: PhantomData<i32>,
-}
+pub struct Srv(());
 
 impl Srv {
     pub fn init() -> ::Result<Srv> {
         unsafe {
             let r = srvInit();
             if r < 0 {
-                Err(::Error::from(r))
+                Err(r.into())
             } else {
-                Ok(Srv { pd: PhantomData })
+                Ok(Srv(()))
             }
         }
     }


### PR DESCRIPTION
Usually `()` is used instead of `PhantomData` to keep users from bypassing struct initializers.