### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+
+rust:
+   - nightly-2017-07-18
+   - nightly
+
+matrix:
+   allow_failures:
+      - rust: nightly
+
+script:
+   - cd ctr-std
+   - cargo build
+   - cargo test


### PR DESCRIPTION
Don't forget to go to https://travis-ci.org/ and activate this repo.