### PR TITLE
Display panics via the Error applet

### DIFF
--- a/ctr-std/Cargo.toml
+++ b/ctr-std/Cargo.toml
@@ -15,3 +15,6 @@ default-features = false
 
 [dependencies.ctru-sys]
 path = "../ctru-sys"
+
+[features]
+citra = []

--- a/ctr-std/src/macros.rs
+++ b/ctr-std/src/macros.rs
@@ -43,8 +43,8 @@ macro_rules! panic {
     ($msg:expr) => ({
         $crate::rt::begin_panic($msg, {
             // static requires less code at runtime, more constant data
-            static _FILE_LINE: (&'static str, u32) = (file!(), line!());
-            &_FILE_LINE
+            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(), column!());
+            &_FILE_LINE_COL
         })
     });
     ($fmt:expr, $($arg:tt)+) => ({
@@ -53,8 +53,8 @@ macro_rules! panic {
             // used inside a dead function. Just `#[allow(dead_code)]` is
             // insufficient, since the user may have
             // `#[forbid(dead_code)]` and which cannot be overridden.
-            static _FILE_LINE: (&'static str, u32) = (file!(), line!());
-            &_FILE_LINE
+            static _FILE_LINE_COL: (&'static str, u32, u32) = (file!(), line!(), column!());
+            &_FILE_LINE_COL
         })
     });
 }

--- a/ctr-std/src/panicking.rs
+++ b/ctr-std/src/panicking.rs
@@ -33,8 +33,11 @@ pub extern fn eh_personality() {}
 
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]
-pub extern fn rust_begin_panic(msg: fmt::Arguments, file: &'static str, line: u32) -> ! {
-    begin_panic_fmt(&msg, &(file, line))
+pub extern fn rust_begin_panic(msg: fmt::Arguments,
+                               file: &'static str,
+                               line: u32,
+                               col: u32) -> ! {
+    begin_panic_fmt(&msg, &(file, line, col))
 }
 
 /// The entry point for panicking with a formatted message.
@@ -47,12 +50,12 @@ pub extern fn rust_begin_panic(msg: fmt::Arguments, file: &'static str, line: u3
            reason = "used by the panic! macro",
            issue = "0")]
 #[inline(never)] #[cold]
-pub fn begin_panic_fmt(msg: &fmt::Arguments, file_line: &(&'static str, u32)) -> ! {
+pub fn begin_panic_fmt(msg: &fmt::Arguments, file_line_col: &(&'static str, u32, u32)) -> ! {
     use fmt::Write;
 
     let mut s = String::new();
     let _ = s.write_fmt(*msg);
-    begin_panic(s, file_line);
+    begin_panic(s, file_line_col);
 }
 
 /// We don't have stack unwinding, so all we do is print the panic message
@@ -61,11 +64,9 @@ pub fn begin_panic_fmt(msg: &fmt::Arguments, file_line: &(&'static str, u32)) ->
            reason = "used by the panic! macro",
            issue = "0")]
 #[inline(never)] #[cold]
-#[inline(never)]
-#[cold]
-pub fn begin_panic<M: Any + Send + Display>(msg: M, file_line: &(&'static str, u32)) -> ! {
+pub fn begin_panic<M: Any + Send + Display>(msg: M, file_line_col: &(&'static str, u32, u32)) -> ! {
     let msg = Box::new(msg);
-    let (file, line) = *file_line;
+    let (file, line, col) = *file_line_col;
 
     use libctru::consoleInit;
     use libctru::gfxScreen_t;

--- a/ctr-std/src/panicking.rs
+++ b/ctr-std/src/panicking.rs
@@ -57,6 +57,10 @@ pub fn begin_panic_fmt(msg: &fmt::Arguments, file_line: &(&'static str, u32)) ->
 
 /// We don't have stack unwinding, so all we do is print the panic message
 /// and then crash or hang the application
+#[unstable(feature = "libstd_sys_internals",
+           reason = "used by the panic! macro",
+           issue = "0")]
+#[inline(never)] #[cold]
 #[inline(never)]
 #[cold]
 pub fn begin_panic<M: Any + Send + Display>(msg: M, file_line: &(&'static str, u32)) -> ! {

--- a/ctru-sys/src/bindings.rs
+++ b/ctru-sys/src/bindings.rs
@@ -1844,7 +1844,7 @@ extern "C" {
     pub fn svcOpenProcess(process: *mut Handle, processId: u32) -> Result;
 }
 extern "C" {
-    pub fn svcExitProcess();
+    pub fn svcExitProcess() -> !;
 }
 extern "C" {
     pub fn svcTerminateProcess(process: Handle) -> Result;


### PR DESCRIPTION
Makes panics look like this:

![Yay for applets!](http://i.imgur.com/OMtC08w.png)

Citra doesn't currently like the error applet, but it works fine on console.