### PR TITLE
Add examples directory

### DIFF
--- a/examples/.cargo/config
+++ b/examples/.cargo/config
@@ -1,0 +1,15 @@
+[build]
+target = "3ds"
+
+[target.3ds]
+linker = "arm-none-eabi-gcc"
+rustflags = [
+    "-Clink-arg=-specs=3dsx.specs",
+    "-Clink-arg=-mfloat-abi=hard",
+    "-Clink-arg=-march=armv6k",
+    "-Clink-arg=-mtune=mpcore",
+    "-Clink-arg=-mfpu=vfp",
+    "-Clink-arg=-mtp=soft",
+    "-Clink-arg=-lsysbase",
+    "-Clink-arg=-lc"
+]

--- a/examples/3ds.json
+++ b/examples/3ds.json
@@ -1,0 +1,19 @@
+{
+  "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", 
+  "llvm-target": "arm-none-eabihf",
+  "linker": "arm-none-eabi-gcc",
+  "ar": "arm-none-eabi-ar",
+  "target-endian": "little",
+  "target-pointer-width": "32",
+  "target-family": "unix",
+  "arch": "arm",
+  "os": "linux",
+  "env": "newlib",
+  "cpu": "mpcore",
+  "features": "+vfp2",
+  "relocation-model": "static",
+  "executables": true,
+  "exe-suffix": ".elf",
+  "panic-strategy": "abort",
+  "linker-flavor": "gcc"
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "examples"
+version = "0.1.0"
+
+[dependencies]
+ctru-rs = { path = "../ctru-rs" }
+
+[profile.release]
+lto = true

--- a/examples/Xargo.toml
+++ b/examples/Xargo.toml
@@ -1,0 +1,6 @@
+[dependencies.collections]
+[dependencies.rand]
+
+[dependencies.std]
+path = "../ctr-std"
+stage = 1

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let dkp_path = env::var("DEVKITPRO").unwrap();
+
+    println!("cargo:rustc-link-search=native={}/libctru/lib", dkp_path);
+    println!("cargo:rustc-link-lib=static={}", match env::var("PROFILE").unwrap().as_str() {
+        "debug" => "ctrud",
+        _       => "ctru",
+    });
+}

--- a/examples/src/bin/hello-both-screens.rs
+++ b/examples/src/bin/hello-both-screens.rs
@@ -1,0 +1,42 @@
+extern crate ctru;
+
+use ctru::gfx::{Gfx, Screen};
+use ctru::console::Console;
+use ctru::services::apt::Apt;
+use ctru::services::hid::{Hid, PadKey};
+
+fn main() {
+    // Initialize services
+    let apt = Apt::init().unwrap();
+    let hid = Hid::init().unwrap();
+    let mut gfx = Gfx::default();
+
+    // Start a console on the top screen
+    let mut top_screen = Console::init(Screen::Top);
+
+    // Start a console on the bottom screen.
+    // The most recently initialized console will be active by default
+    let mut bottom_screen = Console::init(Screen::Bottom);
+
+    // Let's print on the top screen first
+    top_screen.select();
+    println!("This is the top screen! We have a lot of space up here!");
+
+    // Now let's print something on the bottom screen
+    bottom_screen.select();
+    println!("\x1b[14;00HThis is the bottom screen.");
+    println!("There's not as much space down here, but that's okay.");
+
+    top_screen.select();
+    println!("\x1b[29;16HPress Start to exit");
+
+    while apt.main_loop() {
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+
+        hid.scan_input();
+        if hid.key_down(PadKey::Start) {
+            break;
+        }
+    }
+}

--- a/examples/src/bin/hello-world.rs
+++ b/examples/src/bin/hello-world.rs
@@ -1,0 +1,55 @@
+extern crate ctru;
+
+use ctru::gfx::Gfx;
+use ctru::console::Console;
+use ctru::services::apt::Apt;
+use ctru::services::hid::{Hid, PadKey};
+
+fn main() {
+    // Initialize ctrulib service handles.
+    // Service handles are internally reference-counted. When all instances of a
+    // service handle go out of scope, the service will be closed.
+
+    // The APT service handles application management functions, such as
+    // syncing our main loop with the graphics hardware.
+    let apt = Apt::init().unwrap();
+
+    // The HID service handles button and touch screen inputs.
+    let hid = Hid::init().unwrap();
+
+    // The GFX service manages the framebuffers for the top and bottom screens.
+    let mut gfx = Gfx::default();
+
+    // Initialize a ctrulib console and direct standard output to it.
+    // Consoles can be initialized on both the top and bottom screens.
+    // The top screen is initialized by default.
+    let _console = Console::default();
+
+    // Now we can print to stdout!
+    println!("Hello, world!");
+
+    // We can use escape sequences to move the cursor around the terminal.
+    // The following text will be moved down 29 rows and right 16 characters
+    // before printing begins.
+    println!("\x1b[29;16HPress Start to exit");
+
+    // Main application loop.
+    while apt.main_loop() {
+
+        // Flushes and swaps the framebuffers when double-buffering
+        // is enabled
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+
+        // Scan for user input.
+        hid.scan_input();
+        // Check if the user has pressed the given button on this frame.
+        // If so, break out of the loop.
+        if hid.key_down(PadKey::Start) {
+            break;
+        }
+    }
+
+    // All of our service handles will drop out of scope at this point,
+    // triggering the end of our application.
+}


### PR DESCRIPTION
Now that we've got CI running, this should allow us to check if we can successfully build and link binaries without having to use the template repo, as well as letting us show a wider variety of examples. I figure we should still keep the template up to date too, but hopefully this will be a more self-contained way of testing things out.

If you feel like that's a good thing to do, then let me know and I can push an updated Travis config