### PR TITLE
Rewrite rwlock's implementation

### DIFF
--- a/ctr-std/src/sys/unix/mutex.rs
+++ b/ctr-std/src/sys/unix/mutex.rs
@@ -46,8 +46,8 @@ impl Mutex {
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
         match ::libctru::LightLock_TryLock(self.inner.get()) {
-            0 => true,
-            _ => false,
+            0 => false,
+            _ => true,
         }
     }
 
@@ -77,8 +77,8 @@ impl ReentrantMutex {
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
         match ::libctru::RecursiveLock_TryLock(self.inner.get()) {
-            0 => true,
-            _ => false,
+            0 => false,
+            _ => true,
         }
     }
 

--- a/ctr-std/src/sys/unix/rwlock.rs
+++ b/ctr-std/src/sys/unix/rwlock.rs
@@ -97,7 +97,7 @@ impl RWLock {
     pub unsafe fn write_unlock(&self) {
         self.mutex.lock();
         *self.writer_active.get() = false;
-        self.cvar.notify_one();
+        self.cvar.notify_all();
         self.mutex.unlock();
     }
 


### PR DESCRIPTION
Well, more like "actually write an rwlock impl". The previous implementation was basically "pretend to be a mutex and hope no one notices the difference" <.<

I based the implementation off of [this pseudocode](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Using_a_condition_variable_and_a_mutex) from wikipedia. There are probably better implementations out there, but this should at least be serviceable.

The only thing I'm not sure of is if the reader and writer count variables should be modified atomically or not. I think they're fine as-is since all modifications take place while the mutex is locked, but I wouldn't mind a second opinion on that.

~Also not sure if `u8` is too small a value for the reader count.~ I went ahead and made the count a u32 and also added an overflow check just in case someone tries to make more than `u32::max_size()` readers for some reason. Wouldn't be the first time code running on the 3DS was vulnerable to that kind of thing =P