### PR TITLE
Change target spec to horizon instead of linux

### DIFF
--- a/examples/3ds.json
+++ b/examples/3ds.json
@@ -8,7 +8,7 @@
   "target-c-int-width": "32",
   "target-family": "unix",
   "arch": "arm",
-  "os": "linux",
+  "os": "horizon",
   "env": "newlib",
   "cpu": "mpcore",
   "features": "+vfp2",


### PR DESCRIPTION
Because we're not Linux and don't want things trying to use stuff like CLOEXEC that the 3DS doesn't have