### PR TITLE
Filter out a missing glibc symbol

### DIFF
--- a/ctr-std/src/sys/unix/net.rs
+++ b/ctr-std/src/sys/unix/net.rs
@@ -361,6 +361,7 @@ impl IntoInner<c_int> for Socket {
 // res_init unconditionally, we call it only when we detect we're linking
 // against glibc version < 2.26. (That is, when we both know its needed and
 // believe it's thread-safe).
+#[cfg(target_env = "gnu")]
 pub fn res_init_if_glibc_before_2_26() -> io::Result<()> {
     // If the version fails to parse, we treat it the same as "not glibc".
     if let Some(Ok(version_str)) = glibc_version_cstr().map(CStr::to_str) {

--- a/ctr-std/src/sys_common/net.rs
+++ b/ctr-std/src/sys_common/net.rs
@@ -154,7 +154,7 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
             Ok(_) => {
                 Ok(LookupHost { original: res, cur: res })
             },
-            #[cfg(unix)]
+            #[cfg(target_env = "gnu")]
             Err(e) => {
                 // If we're running glibc prior to version 2.26, the lookup
                 // failure could be caused by caching a stale /etc/resolv.conf.
@@ -168,7 +168,7 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
                 Err(e)
             },
             // the cfg is needed here to avoid an "unreachable pattern" warning
-            #[cfg(not(unix))]
+            #[cfg(not(target_env = "gnu"))]
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
This was causing a linker error when building `ctr-std` in debug mode