### PR TITLE
Add Soc service (working network support!)

### DIFF
--- a/ctr-std/src/sys/unix/fd.rs
+++ b/ctr-std/src/sys/unix/fd.rs
@@ -110,33 +110,9 @@ impl FileDesc {
         }
     }
 
-    #[cfg(not(any(target_env = "newlib",
-                  target_os = "solaris",
-                  target_os = "emscripten",
-                  target_os = "fuchsia",
-                  target_os = "l4re",
-                  target_os = "haiku")))]
+    // We don't have fork/exec on the 3DS, so this shouldn't need to do anything
     pub fn set_cloexec(&self) -> io::Result<()> {
-        unsafe {
-            cvt(libc::ioctl(self.fd, libc::FIOCLEX))?;
-            Ok(())
-        }
-    }
-    #[cfg(any(target_env = "newlib",
-              target_os = "solaris",
-              target_os = "emscripten",
-              target_os = "fuchsia",
-              target_os = "l4re",
-              target_os = "haiku"))]
-    pub fn set_cloexec(&self) -> io::Result<()> {
-        unsafe {
-            let previous = cvt(libc::fcntl(self.fd, libc::F_GETFD))?;
-            let new = previous | libc::FD_CLOEXEC;
-            if new != previous {
-                cvt(libc::fcntl(self.fd, libc::F_SETFD, new))?;
-            }
-            Ok(())
-        }
+        Ok(())
     }
 
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -13,6 +13,9 @@ name = "ctru"
 path = "../ctru-sys"
 version = "0.4"
 
+[dependencies.libc]
+version = "0.2"
+
 [dependencies.bitflags]
 version = "1.0.0"
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -3,6 +3,7 @@
 
 #[macro_use]
 extern crate bitflags;
+extern crate libc;
 extern crate widestring;
 
 extern crate ctru_sys as libctru;

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod apt;
 pub mod fs;
 pub mod hid;
 pub mod gspgpu;
+pub mod soc;
 pub mod sslc;
 
 pub use self::hid::Hid;

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -2,15 +2,28 @@ use libctru::{socInit, socExit};
 
 use libc::{memalign, free};
 
+/// Soc service. Initializing this service will enable the use of network sockets and utilities
+/// such as those found in `std::net`. The service will be closed when this struct is is dropped.
 pub struct Soc {
     soc_mem: *mut u32,
 }
 
 impl Soc {
+    /// Initialize the Soc service with a default buffer size of 0x100000 bytes
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the `Soc` service is already initialized
     pub fn init() -> ::Result<Soc> {
         Soc::init_with_buffer_size(0x100000)
     }
 
+    /// Initialize the Soc service with a custom buffer size in bytes. The size should be
+    /// 0x100000 bytes or greater.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the `Soc` service is already initialized
     pub fn init_with_buffer_size(num_bytes: usize) -> ::Result<Soc> {
         unsafe {
             let soc_mem = memalign(0x1000, num_bytes) as *mut u32;

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -8,12 +8,14 @@ pub struct Soc {
 
 impl Soc {
     pub fn init() -> ::Result<Soc> {
-        const SOC_MEM_SIZE: usize = 0x100000;
+        Soc::init_with_buffer_size(0x100000)
+    }
 
+    pub fn init_with_buffer_size(num_bytes: usize) -> ::Result<Soc> {
         unsafe {
-            let soc_mem = memalign(0x1000, SOC_MEM_SIZE) as *mut u32;
+            let soc_mem = memalign(0x1000, num_bytes) as *mut u32;
 
-            let r = socInit(soc_mem, SOC_MEM_SIZE as u32);
+            let r = socInit(soc_mem, num_bytes as u32);
             if r < 0 {
                 Err(r.into())
             } else {

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -1,0 +1,33 @@
+use libctru::{socInit, socExit};
+
+use libc::{memalign, free};
+
+pub struct Soc {
+    soc_mem: *mut u32,
+}
+
+impl Soc {
+    pub fn init() -> ::Result<Soc> {
+        const SOC_MEM_SIZE: usize = 0x100000;
+
+        unsafe {
+            let soc_mem = memalign(0x1000, SOC_MEM_SIZE) as *mut u32;
+
+            let r = socInit(soc_mem, SOC_MEM_SIZE as u32);
+            if r < 0 {
+                Err(r.into())
+            } else {
+                Ok(Soc { soc_mem, })
+            }
+        }
+    }
+}
+
+impl Drop for Soc {
+    fn drop(&mut self) {
+        unsafe {
+            socExit();
+            free(self.soc_mem as *mut _);
+        }
+    }
+}


### PR DESCRIPTION
Took me forever to figure out why every socket-related function threw `EINVAL` when I was working on this. Turns out it's because, despite my [earlier attempt](https://github.com/rust3ds/ctru-rs/pull/57) at removing miscompiled platform-specific behavior, `std` still tried to set `CLOEXEC` on socket descriptors, and `libctru` doesn't know what that means and throws a fit. We don't have the ability to fork/exec processes in a `unix` sense anyway, so once I stubbed that out things finally started working.

Just run `Soc::init()`and stuff in `std::net` should work as long as it doesn't involve IPv6.

