### PR TITLE
Make std::path aware of archive prefixes

### DIFF
--- a/ctr-std/src/path.rs
+++ b/ctr-std/src/path.rs
@@ -201,6 +201,9 @@ impl<'a> Prefix<'a> {
             os_str_as_u8_slice(s).len()
         }
         match *self {
+            #[cfg(target_os = "horizon")]
+            Verbatim(x) => 1 + os_str_len(x),
+            #[cfg(target_os = "windows")]
             Verbatim(x) => 4 + os_str_len(x),
             VerbatimUNC(x, y) => {
                 8 + os_str_len(x) +
@@ -325,7 +328,8 @@ unsafe fn u8_slice_as_os_str(s: &[u8]) -> &OsStr {
 
 // Detect scheme on Redox
 fn has_redox_scheme(s: &[u8]) -> bool {
-    cfg!(target_os = "redox") && s.split(|b| *b == b'/').next().unwrap_or(b"").contains(&b':')
+    (cfg!(target_os = "redox") || cfg!(target_os = "horizon"))
+    && s.split(|b| *b == b'/').next().unwrap_or(b"").contains(&b':')
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1736,7 +1740,7 @@ impl Path {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow(deprecated)]
     pub fn is_absolute(&self) -> bool {
-        if cfg!(target_os = "redox") {
+        if cfg!(target_os = "redox") || cfg!(target_os = "horizon") {
             // FIXME: Allow Redox prefixes
             self.has_root() || has_redox_scheme(self.as_u8_slice())
         } else {

--- a/ctr-std/src/sys/unix/path.rs
+++ b/ctr-std/src/sys/unix/path.rs
@@ -21,8 +21,16 @@ pub fn is_verbatim_sep(b: u8) -> bool {
     b == b'/'
 }
 
-pub fn parse_prefix(_: &OsStr) -> Option<Prefix> {
-    None
+pub fn parse_prefix(path: &OsStr) -> Option<Prefix> {
+    if let Some(path_str) = path.to_str() {
+        if let Some(i) = path_str.find(':') {
+            Some(Prefix::Verbatim(OsStr::new(&path_str[..i])))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }
 
 pub const MAIN_SEP_STR: &'static str = "/";


### PR DESCRIPTION
Thanks to some nice abstractions provided by `libctru`, we are able to manipulate files on both the `sdmc:` and `romfs:` drives using the standard functions in the `std::fs` module. However, `std::path` doesn't understand the `sdmc:` and `romfs:` prefixes by default. For example, iterating over the components of the path `sdmc:/foo/bar.txt` will currently produce the following nonsensical result:
```Rust
Normal("sdmc:")
Normal("foo")
Normal("bar.txt")
```

With these changes, the components would be resolved like so:
```Rust
Prefix(PrefixComponent { raw: "sdmc:", parsed: Verbatim("sdmc") })
RootDir
Normal("foo")
Normal("bar.txt")
```
`Redox` [once proposed](https://internals.rust-lang.org/t/fixing-path-prefix-portability/4459) this exact patch to the real `libstd` (since it uses path prefixes almost exactly like `libctru`'s), but it was rejected/put on the backburner because it was technically a breaking change and they weren't sure about it yet. We can probably be more lenient given that we're not the real `libstd`, but I thought I would bring that up just in case this turns out to be a Bad Idea somehow.

Note that even without this change, you can still use `sdmc:` and `romfs:` paths to open files and directories  since `libctru`'s fs syscall layer knows how to handle them. It's just `std::path` that doesn't yet.
